### PR TITLE
Potential fix for code scanning alert no. 1: SQL query built from user-controlled sources

### DIFF
--- a/server/routes.py
+++ b/server/routes.py
@@ -13,7 +13,8 @@ def index():
 
     if name:
         cursor.execute(
-            "SELECT * FROM books WHERE name LIKE '%" + name + "%'"
+            "SELECT * FROM books WHERE name LIKE %s",
+            ("%" + name + "%",)
         )
         books = [Book(*row) for row in cursor]
 


### PR DESCRIPTION
Potential fix for [https://github.com/angel-rondon/skills-introduction-to-codeql/security/code-scanning/1](https://github.com/angel-rondon/skills-introduction-to-codeql/security/code-scanning/1)

In general, SQL queries that incorporate user input should use parameterized queries/placeholders provided by the database driver (e.g., `%s` for many DB-API 2.0 drivers) instead of string concatenation. The driver then safely escapes and quotes the parameter values, preventing user input from altering the query structure.

For this specific case, the fix is to change the `name` branch to use a parameterized `LIKE` query instead of concatenating `name` into the SQL string. We can keep the wildcard behavior by putting the `%` wildcards into the parameter value rather than into the SQL string itself. Concretely, in `server/routes.py`, lines 14–19, replace:

```python
if name:
    cursor.execute(
        "SELECT * FROM books WHERE name LIKE '%" + name + "%'"
    )
    books = [Book(*row) for row in cursor]
```

with something like:

```python
if name:
    cursor.execute(
        "SELECT * FROM books WHERE name LIKE %s",
        ("%" + name + "%",)
    )
    books = [Book(*row) for row in cursor]
```

This preserves the search semantics while removing the injection risk. No new imports or helper methods are needed; we only change how `cursor.execute` is called. Note that most DB-API drivers expect the second argument to be a sequence (e.g., tuple) of parameters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
